### PR TITLE
#26 bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Bug fix.([Issue #26](https://github.com/overdrive1708/WindowsDeviceManager/issues/26))
+
 ## [1.1.0] - 2023-09-09
 
 ### Added

--- a/src/WindowsDeviceManagerAgent/BitLockerStatusInfoCollector.cs
+++ b/src/WindowsDeviceManagerAgent/BitLockerStatusInfoCollector.cs
@@ -21,13 +21,26 @@ namespace WindowsDeviceManagerAgent
 
             foreach (DriveInfo drive in drives)
             {
-                // 固定ディスクで｢Google Drive｣ではないドライブのBitLocker状態を取得
-                if((drive.DriveType == DriveType.Fixed) && (drive.VolumeLabel != "Google Drive"))
+                try
                 {
+                    // 固定ディスクで｢Google Drive｣ではないドライブのBitLocker状態を取得
+                    if ((drive.DriveType == DriveType.Fixed) && (drive.VolumeLabel != "Google Drive"))
+                    {
+                        BitLockerStatusInfo bitLockerStatusInfo = new()
+                        {
+                            DriveLetter = drive.Name,
+                            BitLockerStatus = GetDriveBitLockerStatus(drive.Name)
+                        };
+                        bitLockerStatusInfos.Add(bitLockerStatusInfo);
+                    }
+                }
+                catch
+                {
+                    // 例外が発生してBitLockerの状態を取得できない場合は状態不明として扱う
                     BitLockerStatusInfo bitLockerStatusInfo = new()
                     {
                         DriveLetter = drive.Name,
-                        BitLockerStatus = GetDriveBitLockerStatus(drive.Name)
+                        BitLockerStatus = BitLockerStatusInfo.Status.Unknown
                     };
                     bitLockerStatusInfos.Add(bitLockerStatusInfo);
                 }


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #26 

## 対応内容 / Correspondence contents

DriveInfo クラスのVolumeLabelを参照する箇所をtry文で囲み､例外をcatchしたときにはBitLockerの状態を｢不明｣として扱うようにした｡

## 制約事項 / Restriction

―

## テスト内容 / Test

- try文のなかで例外をthrowして､処理が止まらずに最後まで進むことを確認した
- BitLocker状態が不明として記録されることを確認した

## 補足情報 / Additional context

―