### PR TITLE
#30 bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Bug fix.([Issue #30](https://github.com/overdrive1708/WindowsDeviceManager/issues/30))
+
 ## [1.2.0] - 2023-09-16
 
 ### Changed

--- a/src/WindowsDeviceManagerAgent/ExceptionHandler.cs
+++ b/src/WindowsDeviceManagerAgent/ExceptionHandler.cs
@@ -48,6 +48,10 @@
             ConsoleWrapper.WriteErrorLine(Resources.Strings.ImportantNotice);
             ConsoleWrapper.WriteErrorLine(Resources.Strings.MessageFatalError);
 
+            // アプリケーションの終了待ち
+            ConsoleWrapper.WriteLine(Resources.Strings.MessagePause);
+            _ = ConsoleWrapper.ReadKey();
+
             // 終了する｡
             Environment.Exit(1);
         }


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #30

## 対応内容 / Correspondence contents

例外発生時に終了する前にキー押下を待つ処理を追加した｡

## 制約事項 / Restriction

なし

## テスト内容 / Test

verboseオプションを指定して起動させた｡
ソフト内部を書き換えて意図的に例外をスローさせて､終了前にキー押下待ちになることをかくにんした｡

## 補足情報 / Additional context

なし