### PR TITLE
#31 bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bug fix.([Issue #30](https://github.com/overdrive1708/WindowsDeviceManager/issues/30))
+- Bug fix.([Issue #31](https://github.com/overdrive1708/WindowsDeviceManager/issues/31))
 
 ## [1.2.0] - 2023-09-16
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ WindowsDeviceManagerViewerフォルダ内のWindowsDeviceManagerViewer.exeを起
   - Version 21H2
   - Version 22H2
 
+## 制限事項
+- リモートデスクトップでログインしている時は､ユーザ名が取得できないため､｢不明｣と記録されます｡
+
 ## 開発環境
 - Microsoft Visual Studio Community 2022
 

--- a/src/WindowsDeviceManagerAgent/WindowsDeviceInfoCollector.cs
+++ b/src/WindowsDeviceManagerAgent/WindowsDeviceInfoCollector.cs
@@ -58,11 +58,19 @@ namespace WindowsDeviceManagerAgent
         {
             string userName = Resources.Strings.Unknown;
 
-            ManagementClass mc = new("Win32_ComputerSystem");
-            ManagementObjectCollection moc = mc.GetInstances();
-            foreach (ManagementObject mo in moc.Cast<ManagementObject>())
+            try
             {
-                userName = mo["UserName"].ToString();
+                ManagementClass mc = new("Win32_ComputerSystem");
+                ManagementObjectCollection moc = mc.GetInstances();
+                foreach (ManagementObject mo in moc.Cast<ManagementObject>())
+                {
+                    userName = mo["UserName"].ToString();
+                }
+            }
+            catch (NullReferenceException)
+            {
+                // リモートデスクトップでログインした状態で実行するとNullReferenceExceptionが発生する｡
+                // 無処理でUnknownを返す｡
             }
 
             return userName;


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #31

## 対応内容 / Correspondence contents

NullReferenceExceptionが発生したときにユーザ名：Unknownとして記録を行うようにした｡

## 制約事項 / Restriction

なし

## テスト内容 / Test

例外をスローするコードを埋め込んで処理が止まらずに､ユーザ名がUnknownになることを確認した｡

## 補足情報 / Additional context

なし