### PR TITLE
#32 add support windows11 23h2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support Windows11 23H2.
+
 ### Fixed
 - Bug fix.([Issue #30](https://github.com/overdrive1708/WindowsDeviceManager/issues/30))
 - Bug fix.([Issue #31](https://github.com/overdrive1708/WindowsDeviceManager/issues/31))

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ WindowsDeviceManagerViewerフォルダ内のWindowsDeviceManagerViewer.exeを起
 - Windows11
   - Version 21H2
   - Version 22H2
+  - Version 23H2
 
 ## 制限事項
 - リモートデスクトップでログインしている時は､ユーザ名が取得できないため､｢不明｣と記録されます｡

--- a/src/WindowsDeviceManagerAgent/WindowsDeviceInfoCollector.cs
+++ b/src/WindowsDeviceManagerAgent/WindowsDeviceInfoCollector.cs
@@ -152,6 +152,7 @@ namespace WindowsDeviceManagerAgent
                 {
                     "22000" => "21H2",
                     "22621" => "22H2",
+                    "22631" => "23H2",
                     _ => $"{Resources.Strings.Unknown}(OS Build:{osBuildNumber})"
                 };
             }

--- a/src/WindowsDeviceManagerViewer/Utilities/DatabaseWriter.cs
+++ b/src/WindowsDeviceManagerViewer/Utilities/DatabaseWriter.cs
@@ -101,6 +101,7 @@ namespace WindowsDeviceManagerViewer.Utilities
                 {
                     "22000" => "21H2",
                     "22621" => "22H2",
+                    "22631" => "23H2",
                     _ => $"{Resources.Strings.Unknown}(OS Build:{osBuildNumber})"
                 };
             }


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #32

## 対応内容 / Correspondence contents

Windows 11 23H2に対応した｡

## 制約事項 / Restriction

なし

## テスト内容 / Test

Agent：Windows11 23H2のPCで実行して23H2として記録されることを確認した｡
Viewer：Unknown(22631)が記録されたDBを再判定して23H2になることを確認した｡

## 補足情報 / Additional context

なし