### PR TITLE
Disalbe IncludeSourceRevisionInInformationalVersion

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,5 +5,6 @@
     <Copyright>Copyright © 2023 overdrive1708</Copyright>
     <PackageProjectUrl>https://github.com/overdrive1708/WindowsDeviceManager</PackageProjectUrl>
     <NeutralLanguage>ja-JP</NeutralLanguage>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## 対応したIssue / Issue addressed

ー

## 対応内容 / Correspondence contents

IncludeSourceRevisionInInformationalVersionをfalseにしてInformationalVersionにSourceRevisionIdを含まないようにした｡

## 制約事項 / Restriction

ー

## テスト内容 / Test

Agent：-vオプションと--versionオプションでVer.x.x.xの後ろに情報が付加されなくなったことを確認した｡
Viewer：タイトルと右下でVer.x.x.x.の後ろに情報が付加されなくなったことを確認した｡

## 補足情報 / Additional context

ー