### PR TITLE
#70 bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Bug fix.([Issue #70](https://github.com/overdrive1708/WindowsDeviceManager/issues/70))
+
 ## [1.5.0] - 2024-08-04
 
 ### Added

--- a/src/WindowsDeviceManagerViewer/Utilities/DatabaseReader.cs
+++ b/src/WindowsDeviceManagerViewer/Utilities/DatabaseReader.cs
@@ -21,7 +21,7 @@ namespace WindowsDeviceManagerViewer.Utilities
             if (File.Exists(databasefile))
             {
                 string databaseVersion = GetDatabaseUserVersion(databasefile);
-                using SQLiteConnection connection = new($"Data Source = {databasefile}");
+                using SQLiteConnection connection = new($"Data Source = {databasefile.Replace(@"\\",@"\\\\")}");
                 connection.Open();
                 using (SQLiteCommand command = connection.CreateCommand())
                 {
@@ -153,7 +153,7 @@ namespace WindowsDeviceManagerViewer.Utilities
         {
             string version = string.Empty;
 
-            using SQLiteConnection connection = new($"Data Source = {databasefile}");
+            using SQLiteConnection connection = new($"Data Source = {databasefile.Replace(@"\\", @"\\\\")}");
             connection.Open();
             using (SQLiteCommand command = connection.CreateCommand())
             {

--- a/src/WindowsDeviceManagerViewer/Utilities/DatabaseWriter.cs
+++ b/src/WindowsDeviceManagerViewer/Utilities/DatabaseWriter.cs
@@ -25,7 +25,7 @@ namespace WindowsDeviceManagerViewer.Utilities
                     // OSバージョンが不明になっているものを再判定して更新する
                     if (readRecord.OSVersion.Contains(Resources.Strings.Unknown))
                     {
-                        using SQLiteConnection connection = new($"Data Source = {databasefile}");
+                        using SQLiteConnection connection = new($"Data Source = {databasefile.Replace(@"\\", @"\\\\")}");
                         connection.Open();
                         using (SQLiteCommand command = connection.CreateCommand())
                         {
@@ -51,7 +51,7 @@ namespace WindowsDeviceManagerViewer.Utilities
             if (File.Exists(databasefile))
             {
                 // データベースファイルがある場合はVACUUMコマンドを実行
-                using SQLiteConnection connection = new($"Data Source = {databasefile}");
+                using SQLiteConnection connection = new($"Data Source = {databasefile.Replace(@"\\", @"\\\\")}");
                 connection.Open();
                 using (SQLiteCommand command = connection.CreateCommand())
                 {


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #70

## 対応内容 / Correspondence contents

Viewer：SQLiteConnectionでファイルを開くときに文字列置き換えを行ってSQLiteが認識できる文字列にした｡

## 制約事項 / Restriction

―

## テスト内容 / Test

UNCパスで開けることと､クリーン･再判定ができることを確認した｡
通常のパスも問題ないことを確認した｡

## 補足情報 / Additional context

―