### PR TITLE
#72 bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bug fix.([Issue #70](https://github.com/overdrive1708/WindowsDeviceManager/issues/70))
+- Bug fix.([Issue #72](https://github.com/overdrive1708/WindowsDeviceManager/issues/72))
 
 ## [1.5.0] - 2024-08-04
 

--- a/src/WindowsDeviceManagerAgent/WindowsDeviceInfoCollector.cs
+++ b/src/WindowsDeviceManagerAgent/WindowsDeviceInfoCollector.cs
@@ -396,7 +396,7 @@ namespace WindowsDeviceManagerAgent
                 // Javaがインストールされているかどうか確認
                 foreach (InstalledApplicationInfo installedApp in installedApps)
                 {
-                    if (installedApp.Name.Contains("java", StringComparison.OrdinalIgnoreCase))
+                    if ((installedApp.Name.Contains("java", StringComparison.OrdinalIgnoreCase)) && (!installedApp.Name.Contains("javascript", StringComparison.OrdinalIgnoreCase)))
                     {
                         javaVersioncheckResult += $"Name=[{installedApp.Name}], Version=[{installedApp.Version}], Publisher=[{installedApp.Publisher}];";
                         isFindJava = true;


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #72

## 対応内容 / Correspondence contents

"JavaScript"を"Java"として判断しないように修正した｡

## 制約事項 / Restriction

―

## テスト内容 / Test

"Java"としたら検出され､"JavaScript"としたら検出されないことを確認した｡

## 補足情報 / Additional context

―