### PR TITLE
#60 localization commandlineparser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Translations of commandlineparser.
+
 ### Fixed
 - Bug fix.([Issue #70](https://github.com/overdrive1708/WindowsDeviceManager/issues/70))
 - Bug fix.([Issue #72](https://github.com/overdrive1708/WindowsDeviceManager/issues/72))

--- a/src/WindowsDeviceManagerAgent/LocalizableSentenceBuilder.cs
+++ b/src/WindowsDeviceManagerAgent/LocalizableSentenceBuilder.cs
@@ -1,0 +1,120 @@
+﻿using CommandLine;
+using CommandLine.Text;
+
+namespace WindowsDeviceManagerAgent
+{
+    public class LocalizableSentenceBuilder : SentenceBuilder
+    {
+        public override Func<string> RequiredWord => () => Resources.Strings.SentenceRequiredWord;
+
+        public override Func<string> OptionGroupWord => () => Resources.Strings.SentenceOptionGroupWord;
+
+        public override Func<string> ErrorsHeadingText => () => Resources.Strings.SentenceErrorsHeadingText;
+
+        public override Func<string> UsageHeadingText => () => Resources.Strings.SentenceUsageHeadingText;
+
+        public override Func<bool, string> HelpCommandText => isOption => isOption
+                                                                               ? Resources.Strings.SentenceHelpCommandTextOption
+                                                                               : Resources.Strings.SentenceHelpCommandTextVerb;
+
+        public override Func<bool, string> VersionCommandText => _ => Resources.Strings.SentenceVersionCommandText;
+
+        public override Func<Error, string> FormatError
+        {
+            get
+            {
+                return error =>
+                {
+                    switch (error.Tag)
+                    {
+                        case ErrorType.BadFormatTokenError:
+                            return string.Format(Resources.Strings.SentenceBadFormatTokenError, ((BadFormatTokenError)error).Token);
+
+                        case ErrorType.MissingValueOptionError:
+                            return string.Format(Resources.Strings.SentenceMissingValueOptionError, ((MissingValueOptionError)error).NameInfo.NameText);
+
+                        case ErrorType.UnknownOptionError:
+                            return string.Format(Resources.Strings.SentenceUnknownOptionError, ((UnknownOptionError)error).Token);
+
+                        case ErrorType.MissingRequiredOptionError:
+                            MissingRequiredOptionError errMisssing = (MissingRequiredOptionError)error;
+                            return errMisssing.NameInfo.Equals(NameInfo.EmptyName)
+                                       ? Resources.Strings.SentenceMissingRequiredOptionErrorValue
+                                       : string.Format(Resources.Strings.SentenceMissingRequiredOptionErrorOption, errMisssing.NameInfo.NameText);
+
+                        case ErrorType.BadFormatConversionError:
+                            BadFormatConversionError badFormat = (BadFormatConversionError)error;
+                            return badFormat.NameInfo.Equals(NameInfo.EmptyName)
+                                       ? Resources.Strings.SentenceBadFormatConversionErrorValue
+                                       : string.Format(Resources.Strings.SentenceBadFormatConversionErrorOption, badFormat.NameInfo.NameText);
+
+                        case ErrorType.SequenceOutOfRangeError:
+                            SequenceOutOfRangeError seqOutRange = (SequenceOutOfRangeError)error;
+                            return seqOutRange.NameInfo.Equals(NameInfo.EmptyName)
+                                       ? Resources.Strings.SentenceSequenceOutOfRangeErrorValue
+                                       : string.Format(Resources.Strings.SentenceSequenceOutOfRangeErrorOption, seqOutRange.NameInfo.NameText);
+
+                        case ErrorType.BadVerbSelectedError:
+                            return string.Format(Resources.Strings.SentenceBadVerbSelectedError, ((BadVerbSelectedError)error).Token);
+
+                        case ErrorType.NoVerbSelectedError:
+                            return Resources.Strings.SentenceNoVerbSelectedError;
+
+                        case ErrorType.RepeatedOptionError:
+                            return string.Format(Resources.Strings.SentenceRepeatedOptionError, ((RepeatedOptionError)error).NameInfo.NameText);
+
+                        case ErrorType.SetValueExceptionError:
+                            SetValueExceptionError setValueError = (SetValueExceptionError)error;
+                            return string.Format(Resources.Strings.SentenceSetValueExceptionError, setValueError.NameInfo.NameText, setValueError.Exception.Message);
+
+                        case ErrorType.MissingGroupOptionError:
+                            MissingGroupOptionError missingGroupOptionError = (MissingGroupOptionError)error;
+                            return string.Format(Resources.Strings.MissingGroupOptionError, missingGroupOptionError.Group, missingGroupOptionError.Names.Select(n => n.NameText));
+
+                        case ErrorType.GroupOptionAmbiguityError:
+                            GroupOptionAmbiguityError groupOptionAmbiguityError = (GroupOptionAmbiguityError)error;
+                            return string.Format(Resources.Strings.GroupOptionAmbiguityError, groupOptionAmbiguityError.Option.NameText);
+
+                        case ErrorType.MultipleDefaultVerbsError:
+                            return MultipleDefaultVerbsError.ErrorMessage;
+
+                        default:
+                            throw new InvalidOperationException();
+                    }
+                };
+            }
+        }
+
+        public override Func<IEnumerable<MutuallyExclusiveSetError>, string> FormatMutuallyExclusiveSetErrors
+        {
+            get
+            {
+                return errors =>
+                {
+                    var bySet = from error in errors
+                                group error by error.SetName into g
+                                select new { SetName = g.Key, Errors = g.ToList() };
+
+                    string[] msgs = bySet.Select(
+                        set =>
+                        {
+                            string names = string.Join(
+                                string.Empty,
+                                (from e in set.Errors select string.Format("'{0}', ", e.NameInfo.NameText)).ToArray());
+                            int namesCount = set.Errors.Count;
+
+                            string incompat = string.Join(
+                                string.Empty,
+                                (from x in
+                                    (from s in bySet where !s.SetName.Equals(set.SetName) from e in s.Errors select e)
+                                    .Distinct()
+                                select string.Format("'{0}', ", x.NameInfo.NameText)).ToArray());
+
+                            return string.Format(Resources.Strings.SentenceMutuallyExclusiveSetErrors, names[..^2], incompat[..^2]);
+                        }).ToArray();
+                    return string.Join(Environment.NewLine, msgs);
+                };
+            }
+        }
+    }
+}

--- a/src/WindowsDeviceManagerAgent/Program.cs
+++ b/src/WindowsDeviceManagerAgent/Program.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using CommandLine.Text;
 using System.Reflection;
 
 namespace WindowsDeviceManagerAgent
@@ -13,6 +14,9 @@ namespace WindowsDeviceManagerAgent
         {
             // 未処理の例外が発生したときの処理を登録する｡
             EntryExceptionHandler();
+
+            // CommandLineParserのSentenceBuilderの多言語化を行う｡
+            SentenceBuilder.Factory = () => new LocalizableSentenceBuilder();
 
             // コマンドライン引数を解析する｡
             _ = Parser.Default.ParseArguments<CommandLineOptions>(args)

--- a/src/WindowsDeviceManagerAgent/Resources/Strings.Designer.cs
+++ b/src/WindowsDeviceManagerAgent/Resources/Strings.Designer.cs
@@ -214,6 +214,15 @@ namespace WindowsDeviceManagerAgent.Resources {
         }
         
         /// <summary>
+        ///   オプション： ({0}) では SetName と Group の両方は許されません。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string GroupOptionAmbiguityError {
+            get {
+                return ResourceManager.GetString("GroupOptionAmbiguityError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   処理の結果をファイルに出力します｡(--output [json|xml|csv]) に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string HelpTextOutput {
@@ -378,6 +387,15 @@ namespace WindowsDeviceManagerAgent.Resources {
         }
         
         /// <summary>
+        ///   グループ &apos;{0}&apos; ({1})から少なくとも1つのオプションが必要です。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MissingGroupOptionError {
+            get {
+                return ResourceManager.GetString("MissingGroupOptionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   名前 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string Name {
@@ -428,6 +446,195 @@ namespace WindowsDeviceManagerAgent.Resources {
         public static string Publisher {
             get {
                 return ResourceManager.GetString("Publisher", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   オプション &apos;{0}&apos; が不正なフォーマットで定義されています。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceBadFormatConversionErrorOption {
+            get {
+                return ResourceManager.GetString("SentenceBadFormatConversionErrorOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   オプション名にバインドされていない値が不正なフォーマットで定義されています。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceBadFormatConversionErrorValue {
+            get {
+                return ResourceManager.GetString("SentenceBadFormatConversionErrorValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   トークン &apos;{0}&apos; が認識できません。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceBadFormatTokenError {
+            get {
+                return ResourceManager.GetString("SentenceBadFormatTokenError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   動詞 &apos;{0}&apos; が認識できません｡ に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceBadVerbSelectedError {
+            get {
+                return ResourceManager.GetString("SentenceBadVerbSelectedError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   エラー： に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceErrorsHeadingText {
+            get {
+                return ResourceManager.GetString("SentenceErrorsHeadingText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   ヘルプ画面を表示します。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceHelpCommandTextOption {
+            get {
+                return ResourceManager.GetString("SentenceHelpCommandTextOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   特定のコマンドについての詳細情報を表示します｡ に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceHelpCommandTextVerb {
+            get {
+                return ResourceManager.GetString("SentenceHelpCommandTextVerb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   必須オプション &apos;{0}&apos; がありません。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceMissingRequiredOptionErrorOption {
+            get {
+                return ResourceManager.GetString("SentenceMissingRequiredOptionErrorOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   オプション名にバインドされていない必須の値がありません。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceMissingRequiredOptionErrorValue {
+            get {
+                return ResourceManager.GetString("SentenceMissingRequiredOptionErrorValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   オプション &apos;{0}&apos; に値がありません。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceMissingValueOptionError {
+            get {
+                return ResourceManager.GetString("SentenceMissingValueOptionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   オプション: {0} は {1} と互換性がありません。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceMutuallyExclusiveSetErrors {
+            get {
+                return ResourceManager.GetString("SentenceMutuallyExclusiveSetErrors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   動詞が選択されていません。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceNoVerbSelectedError {
+            get {
+                return ResourceManager.GetString("SentenceNoVerbSelectedError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   グループ に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceOptionGroupWord {
+            get {
+                return ResourceManager.GetString("SentenceOptionGroupWord", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   オプション &apos;{0}&apos; が複数回定義されています。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceRepeatedOptionError {
+            get {
+                return ResourceManager.GetString("SentenceRepeatedOptionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   &lt;必須&gt; に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceRequiredWord {
+            get {
+                return ResourceManager.GetString("SentenceRequiredWord", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   シーケンスオプション &apos;{0}&apos; が、必要な数より少ないか多い項目で定義されています。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceSequenceOutOfRangeErrorOption {
+            get {
+                return ResourceManager.GetString("SentenceSequenceOutOfRangeErrorOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   オプション名にバインドされていないシーケンス値が、必要な項目数よりも少ない項目で定義されています。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceSequenceOutOfRangeErrorValue {
+            get {
+                return ResourceManager.GetString("SentenceSequenceOutOfRangeErrorValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   オプション &apos;{0}&apos; への値の設定エラー： {1} に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceSetValueExceptionError {
+            get {
+                return ResourceManager.GetString("SentenceSetValueExceptionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   オプション &apos;{0}&apos; が不明です。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceUnknownOptionError {
+            get {
+                return ResourceManager.GetString("SentenceUnknownOptionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   使い方： に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceUsageHeadingText {
+            get {
+                return ResourceManager.GetString("SentenceUsageHeadingText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   バージョン情報を表示します。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string SentenceVersionCommandText {
+            get {
+                return ResourceManager.GetString("SentenceVersionCommandText", resourceCulture);
             }
         }
         

--- a/src/WindowsDeviceManagerAgent/Resources/Strings.resx
+++ b/src/WindowsDeviceManagerAgent/Resources/Strings.resx
@@ -234,4 +234,96 @@
   <data name="Publisher" xml:space="preserve">
     <value>発行元</value>
   </data>
+  <data name="SentenceRequiredWord" xml:space="preserve">
+    <value>&lt;必須&gt;</value>
+    <comment>&lt;Required&gt;</comment>
+  </data>
+  <data name="SentenceOptionGroupWord" xml:space="preserve">
+    <value>グループ</value>
+    <comment>Group</comment>
+  </data>
+  <data name="SentenceErrorsHeadingText" xml:space="preserve">
+    <value>エラー：</value>
+    <comment>ERROR(S):</comment>
+  </data>
+  <data name="SentenceUsageHeadingText" xml:space="preserve">
+    <value>使い方：</value>
+    <comment>USAGE:</comment>
+  </data>
+  <data name="SentenceHelpCommandTextOption" xml:space="preserve">
+    <value>ヘルプ画面を表示します。</value>
+    <comment>Display this help screen.</comment>
+  </data>
+  <data name="SentenceHelpCommandTextVerb" xml:space="preserve">
+    <value>特定のコマンドについての詳細情報を表示します｡</value>
+    <comment>Display more information on a specific command.</comment>
+  </data>
+  <data name="SentenceVersionCommandText" xml:space="preserve">
+    <value>バージョン情報を表示します。</value>
+    <comment>Display version information.</comment>
+  </data>
+  <data name="SentenceBadFormatTokenError" xml:space="preserve">
+    <value>トークン '{0}' が認識できません。</value>
+    <comment>Token '{0}' is not recognized.</comment>
+  </data>
+  <data name="SentenceMissingValueOptionError" xml:space="preserve">
+    <value>オプション '{0}' に値がありません。</value>
+    <comment>Option '{0}' has no value.</comment>
+  </data>
+  <data name="SentenceUnknownOptionError" xml:space="preserve">
+    <value>オプション '{0}' が不明です。</value>
+    <comment>Option '{0}' is unknown.</comment>
+  </data>
+  <data name="SentenceMissingRequiredOptionErrorValue" xml:space="preserve">
+    <value>オプション名にバインドされていない必須の値がありません。</value>
+    <comment>A required value not bound to option name is missing.</comment>
+  </data>
+  <data name="SentenceMissingRequiredOptionErrorOption" xml:space="preserve">
+    <value>必須オプション '{0}' がありません。</value>
+    <comment>Required option '{0}' is missing.</comment>
+  </data>
+  <data name="SentenceBadFormatConversionErrorValue" xml:space="preserve">
+    <value>オプション名にバインドされていない値が不正なフォーマットで定義されています。</value>
+    <comment>A value not bound to option name is defined with a bad format.</comment>
+  </data>
+  <data name="SentenceBadFormatConversionErrorOption" xml:space="preserve">
+    <value>オプション '{0}' が不正なフォーマットで定義されています。</value>
+    <comment>Option '{0}' is defined with a bad format.</comment>
+  </data>
+  <data name="SentenceSequenceOutOfRangeErrorValue" xml:space="preserve">
+    <value>オプション名にバインドされていないシーケンス値が、必要な項目数よりも少ない項目で定義されています。</value>
+    <comment>A sequence value not bound to option name is defined with few items than required.</comment>
+  </data>
+  <data name="SentenceSequenceOutOfRangeErrorOption" xml:space="preserve">
+    <value>シーケンスオプション '{0}' が、必要な数より少ないか多い項目で定義されています。</value>
+    <comment>A sequence option '{0}' is defined with fewer or more items than required.</comment>
+  </data>
+  <data name="SentenceBadVerbSelectedError" xml:space="preserve">
+    <value>動詞 '{0}' が認識できません｡</value>
+    <comment>Verb '{0}' is not recognized.</comment>
+  </data>
+  <data name="SentenceNoVerbSelectedError" xml:space="preserve">
+    <value>動詞が選択されていません。</value>
+    <comment>No verb selected.</comment>
+  </data>
+  <data name="SentenceRepeatedOptionError" xml:space="preserve">
+    <value>オプション '{0}' が複数回定義されています。</value>
+    <comment>Option '{0}' is defined multiple times.</comment>
+  </data>
+  <data name="SentenceSetValueExceptionError" xml:space="preserve">
+    <value>オプション '{0}' への値の設定エラー： {1}</value>
+    <comment>Error setting value to option '{0}': {1}</comment>
+  </data>
+  <data name="MissingGroupOptionError" xml:space="preserve">
+    <value>グループ '{0}' ({1})から少なくとも1つのオプションが必要です。</value>
+    <comment>At least one option from group '{0}' ({1}) is required.</comment>
+  </data>
+  <data name="GroupOptionAmbiguityError" xml:space="preserve">
+    <value>オプション： ({0}) では SetName と Group の両方は許されません。</value>
+    <comment>Both SetName and Group are not allowed in option: ({0})</comment>
+  </data>
+  <data name="SentenceMutuallyExclusiveSetErrors" xml:space="preserve">
+    <value>オプション: {0} は {1} と互換性がありません。</value>
+    <comment>Options: {0} are not compatible with {1}.</comment>
+  </data>
 </root>


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #60 

## 対応内容 / Correspondence contents

CommandLineParserのUIを多言語化した｡

## 制約事項 / Restriction

―

## テスト内容 / Test

helpオプションや不正なオプションを指定して英語部分が日本語になることを確認した｡

## 補足情報 / Additional context

―