### PR TITLE
change publish setting.

### DIFF
--- a/src/WindowsDeviceManagerAgent/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/WindowsDeviceManagerAgent/Properties/PublishProfiles/FolderProfile.pubxml
@@ -12,7 +12,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>net8.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
+    <PublishSingleFile>true</PublishSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 </Project>

--- a/src/WindowsDeviceManagerViewer/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/WindowsDeviceManagerViewer/Properties/PublishProfiles/FolderProfile.pubxml
@@ -12,7 +12,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>net8.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
+    <PublishSingleFile>true</PublishSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## 対応したIssue / Issue addressed

―

## 対応内容 / Correspondence contents

発行用の設定｢PublishSingleFile｣をtrueにして1ファイルにするようにした｡
System.Data.SQLite.Core：1.0.118の制約事項のため1ファイルにまとめられなかったが､1.0.119で修正されたため対応できるようになった｡

## 制約事項 / Restriction

―

## テスト内容 / Test

発行してexeファイル1つになることを確認した｡
Agent：verboseオプションで収集を確認した｡
Viewer：収集結果を開けることを確認した｡

## 補足情報 / Additional context

―