### PR TITLE
Add recheck java check result function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Collect and show windows device information.
     - InstallCheckResult
+- Recheck Java check result function.
 
 ### Changed
 - Translations of commandlineparser.
+- Publish single file.
 
 ### Fixed
 - Bug fix.([Issue #70](https://github.com/overdrive1708/WindowsDeviceManager/issues/70))
 - Bug fix.([Issue #72](https://github.com/overdrive1708/WindowsDeviceManager/issues/72))
 - Bug fix.([Issue #74](https://github.com/overdrive1708/WindowsDeviceManager/issues/74))
+
+### Security
+- Libraries versionup.
 
 ## [1.5.0] - 2024-08-04
 

--- a/src/WindowsDeviceManagerViewer/Resources/Strings.Designer.cs
+++ b/src/WindowsDeviceManagerViewer/Resources/Strings.Designer.cs
@@ -316,6 +316,15 @@ namespace WindowsDeviceManagerViewer.Resources {
         }
         
         /// <summary>
+        ///   Javaバージョン再判定が完了しました｡ に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string MessageRecheckJavaVersionComplete {
+            get {
+                return ResourceManager.GetString("MessageRecheckJavaVersionComplete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   OSバージョン再判定が完了しました｡ に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string MessageRecheckOSVersionComplete {
@@ -451,6 +460,15 @@ namespace WindowsDeviceManagerViewer.Resources {
         }
         
         /// <summary>
+        ///   Javaバージョン再判定 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string RecheckJavaVersion {
+            get {
+                return ResourceManager.GetString("RecheckJavaVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   OSバージョン再判定 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string RecheckOSVersion {
@@ -474,6 +492,15 @@ namespace WindowsDeviceManagerViewer.Resources {
         public static string SQLiteDatabaseFile {
             get {
                 return ResourceManager.GetString("SQLiteDatabaseFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   未検出 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Undetected {
+            get {
+                return ResourceManager.GetString("Undetected", resourceCulture);
             }
         }
         

--- a/src/WindowsDeviceManagerViewer/Resources/Strings.resx
+++ b/src/WindowsDeviceManagerViewer/Resources/Strings.resx
@@ -250,4 +250,13 @@
   <data name="InstallCheckResult" xml:space="preserve">
     <value>インストールチェック結果</value>
   </data>
+  <data name="RecheckJavaVersion" xml:space="preserve">
+    <value>Javaバージョン再判定</value>
+  </data>
+  <data name="MessageRecheckJavaVersionComplete" xml:space="preserve">
+    <value>Javaバージョン再判定が完了しました｡</value>
+  </data>
+  <data name="Undetected" xml:space="preserve">
+    <value>未検出</value>
+  </data>
 </root>

--- a/src/WindowsDeviceManagerViewer/ViewModels/MainWindowViewModel.cs
+++ b/src/WindowsDeviceManagerViewer/ViewModels/MainWindowViewModel.cs
@@ -128,6 +128,13 @@ namespace WindowsDeviceManagerViewer.ViewModels
             _commandRecheckOSVersion ?? (_commandRecheckOSVersion = new DelegateCommand(ExecuteCommandRecheckOSVersion));
 
         /// <summary>
+        /// Javaバージョン再判定コマンド
+        /// </summary>
+        private DelegateCommand _commandRecheckJavaVersion;
+        public DelegateCommand CommandRecheckJavaVersion =>
+            _commandRecheckJavaVersion ?? (_commandRecheckJavaVersion = new DelegateCommand(ExecuteCommandRecheckJavaVersion));
+
+        /// <summary>
         /// 表示データリロードコマンド
         /// </summary>
         private DelegateCommand _commandReloadDisplayData;
@@ -233,6 +240,35 @@ namespace WindowsDeviceManagerViewer.ViewModels
 
                 // 完了メッセージの表示
                 _ = MessageBox.Show(Resources.Strings.MessageRecheckOSVersionComplete,
+                                    Resources.Strings.Notice,
+                                    MessageBoxButton.OK,
+                                    MessageBoxImage.Information);
+            }
+            else
+            {
+                // データベースファイルがない場合はエラーメッセージを表示して処理を終わる
+                _ = MessageBox.Show(Resources.Strings.MessageErrorDatabaseNotFound,
+                                    Resources.Strings.Error,
+                                    MessageBoxButton.OK,
+                                    MessageBoxImage.Error);
+            }
+        }
+
+        /// <summary>
+        /// Javaバージョン再判定コマンド実行処理
+        /// </summary>
+        private void ExecuteCommandRecheckJavaVersion()
+        {
+            if (File.Exists(_databaseFileName))
+            {
+                // データベースファイルがある場合はJavaバージョンの再判定を行う
+                DatabaseWriter.RecheckJavaVersion(_databaseFileName);
+
+                // データベースファイルの再読み込み
+                CreateWindowsDeviceInfoCollectData();
+
+                // 完了メッセージの表示
+                _ = MessageBox.Show(Resources.Strings.MessageRecheckJavaVersionComplete,
                                     Resources.Strings.Notice,
                                     MessageBoxButton.OK,
                                     MessageBoxImage.Information);

--- a/src/WindowsDeviceManagerViewer/Views/MainWindow.xaml
+++ b/src/WindowsDeviceManagerViewer/Views/MainWindow.xaml
@@ -266,6 +266,11 @@
                             Style="{StaticResource MaterialDesignOutlinedButton}" />
                         <Button
                             Margin="10,10,10,10"
+                            Command="{Binding CommandRecheckJavaVersion}"
+                            Content="{x:Static resources:Strings.RecheckJavaVersion}"
+                            Style="{StaticResource MaterialDesignOutlinedButton}" />
+                        <Button
+                            Margin="10,10,10,10"
                             Command="{Binding CommandReloadDisplayData}"
                             Content="{x:Static resources:Strings.Reload}"
                             Style="{StaticResource MaterialDesignOutlinedButton}" />


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #85 

## 対応内容 / Correspondence contents

Javaのバージョンチェック結果を再判定して､｢JavaScript｣の検出結果を削除する機能を追加した｡

## 制約事項 / Restriction

―

## テスト内容 / Test

JavaとJavaScriptを含む結果を再判定->Javaだけ残ることを確認した｡
JavaScriptを含む結果を再判定->未検出になることを確認した｡

## 補足情報 / Additional context

―