### PR TITLE
#88 add support windows11 24h2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - InstallCheckResult
 - Recheck Java check result function.
 - Collect item configuration function.
+- Support Windows11 24H2.
 
 ### Changed
 - Translations of commandlineparser.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ WindowsDeviceManagerViewerフォルダ内のWindowsDeviceManagerViewer.exeを起
   - Version 21H2
   - Version 22H2
   - Version 23H2
+  - Version 24H2
 
 ## 制限事項
 - リモートデスクトップでログインしている時は､ユーザ名が取得できないため､｢不明｣と記録されます｡

--- a/src/WindowsDeviceManagerAgent/WindowsDeviceInfoCollector.cs
+++ b/src/WindowsDeviceManagerAgent/WindowsDeviceInfoCollector.cs
@@ -211,6 +211,7 @@ namespace WindowsDeviceManagerAgent
                         "22000" => "21H2",
                         "22621" => "22H2",
                         "22631" => "23H2",
+                        "26100" => "24H2",
                         _ => $"{Resources.Strings.Unknown}(OS Build:{osBuildNumber})"
                     };
                 }

--- a/src/WindowsDeviceManagerViewer/Utilities/DatabaseWriter.cs
+++ b/src/WindowsDeviceManagerViewer/Utilities/DatabaseWriter.cs
@@ -155,6 +155,7 @@ namespace WindowsDeviceManagerViewer.Utilities
                     "22000" => "21H2",
                     "22621" => "22H2",
                     "22631" => "23H2",
+                    "26100" => "24H2",
                     _ => $"{Resources.Strings.Unknown}(OS Build:{osBuildNumber})"
                 };
             }


### PR DESCRIPTION
## 対応したIssue / Issue addressed

Fix #88

## 対応内容 / Correspondence contents

Windows 11 24H2に対応した｡

## 制約事項 / Restriction

なし

## テスト内容 / Test

Agent：デバッガでビルド番号を書き換えて26100としたとき､24H2として記録されることを確認した｡
Viewer：Unknown(26100)が記録されたDBを再判定して24H2になることを確認した｡

## 補足情報 / Additional context

なし
